### PR TITLE
Cursor Visibility in Settings

### DIFF
--- a/src/Settings/index.js
+++ b/src/Settings/index.js
@@ -99,7 +99,7 @@ class Settings extends Component {
 
                     </select>
                     <FormText>
-                      Select mouse cursor visibility.
+                      Select mouse cursor visibility. (Will not work on iFrames)
                     </FormText>
                   </FormGroup>
                   <Button

--- a/src/Settings/index.js
+++ b/src/Settings/index.js
@@ -99,7 +99,7 @@ class Settings extends Component {
 
                     </select>
                     <FormText>
-                      Select mouse cursor visibility. (Will not work on iFrames)
+                      Select mouse cursor visibility. Does not work with iFrames.
                     </FormText>
                   </FormGroup>
                   <Button

--- a/src/Settings/index.js
+++ b/src/Settings/index.js
@@ -21,19 +21,23 @@ class Settings extends Component {
 
     this.state = {
       displayHome: '',
+      cursorVisibility: 'show'
     };
   }
 
   componentWillMount() {
-    const displayHome = ipcRenderer.sendSync('settingsGet', 'kiosk.displayHome');
-    this.setState({ displayHome });
+    const kioskSettings = ipcRenderer.sendSync('settingsGet', 'kiosk');
+    let { displayHome, cursorVisibility } = kioskSettings;
+    if (displayHome === undefined) displayHome = '';
+    if (cursorVisibility === undefined) cursorVisibility = 'show';
+    this.setState({ displayHome, cursorVisibility });
   }
 
   render() {
-    const { displayHome } = this.state;
+    const { displayHome, cursorVisibility } = this.state;
     return (
       <Formik
-        initialValues={{ url: displayHome }}
+        initialValues={{ url: displayHome, cursorVis: cursorVisibility }}
         onSubmit={(values, { setSubmitting }) => {
           setTimeout(() => {
             ipcRenderer.send('updateSettings', values);
@@ -78,7 +82,26 @@ class Settings extends Component {
                       Enter the home URL for the kiosk.
                     </FormText>
                   </FormGroup>
+                  <FormGroup>
+                    <Label for="cursorVis">Cursor Visibility</Label>
+                    <select
+                      name="cursorVis"
+                      id="cursorVis"
+                      value={values.cursorVis}
+                      onChange={handleChange}
+                      onBlur={handleBlur}
+                      style={{ display: 'block' }}
+                      >
+                      <option value="show" label="Show" />
+                      <option value="hide" label="Hide" />
+                      <option value="hide_after_5" label="Hide after 5 seconds inactivity" />
+                      <option value="hide_after_60" label="Hide after 60 seconds inactivity" />
 
+                    </select>
+                    <FormText>
+                      Select mouse cursor visibility.
+                    </FormText>
+                  </FormGroup>
                   <Button
                     color="primary"
                     type="submit"
@@ -86,7 +109,6 @@ class Settings extends Component {
                   >
                     Save
                   </Button>
-
                 </Form>
                 </Col>
               </Row>


### PR DESCRIPTION
Allows user to customize whether the mouse cursor should be visible. Can Show, Hide, or Hide after 5/60 seconds inactivity.

Electron injects CSS & JS to hide cursor. We should consider whether we _really_ need to do this through Electron because if it causes any issues with the internal application CSS/JS, it may be difficult to trace back to the Electron Wrapper. Anyways, it works if we want to use it.