### PR TITLE
added flag for not requiring user action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stele",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "private": true,
   "description": "Kiosk app wrapper for museum media exhibits",
   "author": "Science Museum of Minnesota <exhibit.media@smm.org>",
@@ -158,7 +158,10 @@
       ]
     },
     "win": {
-      "target": ["nsis", "msi"]
+      "target": [
+        "nsis",
+        "msi"
+      ]
     },
     "nsis": {
       "artifactName": "${productName}-${os}-${version}-installer.${ext}"

--- a/src/main/main.dev.js
+++ b/src/main/main.dev.js
@@ -45,6 +45,8 @@ if (process.env.NODE_ENV === 'production') {
   sourceMapSupport.install();
 }
 
+app.commandLine.appendSwitch('--autoplay-policy', 'no-user-gesture-required');
+
 app.on('ready', async () => {
   //
   // App settings setup


### PR DESCRIPTION
Added a flag so that user interaction is not required to play audio files. (Specifically, this allows us to trigger audio files to project visualizations in the Time room of the Infestation project.) Playing audio and video without user interaction is disallowed by default in Chrome.