### PR TITLE
fix: Handle bad URL when Stele launches

### DIFF
--- a/src/main/windows/handleWindowLoadFail.js
+++ b/src/main/windows/handleWindowLoadFail.js
@@ -20,6 +20,12 @@ const handleWindowLoadFail = (window, store, logger) => {
           `App - Stele is configured to load an invalid URL(${configuredURL}) - ${errorDescription}:${errorCode}`,
         );
         mainWindowNavigateSettings(window, store);
+      } else if (errorCode === -3) {
+        // This errorCode is a false positive.
+        // A 'did-finish-load' event will fire immediately after.
+        // This seems to happen while using a hot-reload development server.
+        // https://github.com/electron/electron/issues/4396
+        console.log('Ignoring "did-fail-load" error code: -3.');
       } else {
         logger.error(`App - Unknown web contents load failure - ${errorDescription}:${errorCode}`);
         app.quit();

--- a/src/main/windows/handleWindowLoadFail.js
+++ b/src/main/windows/handleWindowLoadFail.js
@@ -23,10 +23,10 @@ const handleWindowLoadFail = (window, store, logger) => {
         mainWindowNavigateSettings(window, store);
       } else if (errorCode === -3) {
         // This errorCode is a false positive.
-        // A 'did-finish-load' event will fire immediately after.
-        // This seems to happen while using a hot-reload development server.
+        // A 'did-finish-load' event will fire immediately after 'did-fail-load'.
+        // This happens while using a hot-reload development server.
         // https://github.com/electron/electron/issues/4396
-        logger.info('App - Ignoring "did-fail-load" error code: -3.');
+        logger.info('App - Ignoring "did-fail-load" error code: -3');
       } else {
         logger.error(`App - Unknown web contents load failure - ${errorDescription}:${errorCode}`);
         app.quit();

--- a/src/main/windows/handleWindowLoadFail.js
+++ b/src/main/windows/handleWindowLoadFail.js
@@ -14,6 +14,7 @@ const handleWindowLoadFail = (window, store, logger) => {
       if (
         errorDescription === 'ERR_INVALID_URL'
         || errorDescription === 'ERR_NAME_NOT_RESOLVED'
+        || errorDescription === 'ERR_ADDRESS_UNREACHABLE'
       ) {
         const configuredURL = _.get(store.get('kiosk'), 'displayHome');
         logger.info(
@@ -25,7 +26,7 @@ const handleWindowLoadFail = (window, store, logger) => {
         // A 'did-finish-load' event will fire immediately after.
         // This seems to happen while using a hot-reload development server.
         // https://github.com/electron/electron/issues/4396
-        console.log('Ignoring "did-fail-load" error code: -3.');
+        logger.info('App - Ignoring "did-fail-load" error code: -3.');
       } else {
         logger.error(`App - Unknown web contents load failure - ${errorDescription}:${errorCode}`);
         app.quit();


### PR DESCRIPTION
If Stele launches and is configure to point to a bad URL that can't be loaded, the app shouldn't immediately crash.

Bug report: https://smm.atlassian.net/browse/EXTCH-56

Trygve's fix here addresses this

EXTCH-56

Merging this into the active project work on updating Stele to some modern packages.